### PR TITLE
Added call to base-class constructor.

### DIFF
--- a/flask_twisted/__init__.py
+++ b/flask_twisted/__init__.py
@@ -12,6 +12,7 @@ from observable import Observable
 class Twisted(Observable):
 
     def __init__(self, app=None):
+        Observable.__init__(self)
         self.app = None
         self.resources = {}
 


### PR DESCRIPTION
This corrects a fatal error that prevents flask-twisted from being used. 