### PR TITLE
feat(examples): add a demo for flask-twisted

### DIFF
--- a/examples/flask_twisted.py
+++ b/examples/flask_twisted.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from flask import Flask
+from flask import  render_template  
+
+#from flask.ext.twisted import Twisted
+from flask_twisted import Twisted
+
+app = Flask(__name__)
+
+@app.route('/')  
+@app.route('/<name>')  
+def index(name=None):  
+    print 'come into index'
+    return render_template('hello.html', name=name)  
+
+twisted = Twisted(app)
+
+
+if __name__ == "__main__":
+    print 'come into main'
+    twisted.run(host='0.0.0.0',port=13579, debug=False) 
+    #app.run(host='0.0.0.0',port=13579, debug=False) 

--- a/examples/templates/hello.html
+++ b/examples/templates/hello.html
@@ -1,0 +1,6 @@
+from Flask</title>  
+{% if name %}  
+<h1>Hello {{ name }}!</h1>  
+{% else %}  
+<h1>Hello World!</h1>  
+{% endif %}  


### PR DESCRIPTION
In the example, we can see something in browser.

In the `examples`,  there is only one `hello` and it does not show `flask-twisted` very well.

Hope the commit can help someone who is interested in the module `interested`.